### PR TITLE
cookie support & stuff

### DIFF
--- a/add-on/background.js
+++ b/add-on/background.js
@@ -19,15 +19,37 @@ function notify(message) {
   });
 }
 
+/* thanks @Lemmon Hill for https://github.com/lennonhill/cookies-txt */
+function formatCookie(co) {
+  return [
+    [
+      co.httpOnly ? '#HttpOnly_' : '',
+      !co.hostOnly && co.domain && !co.domain.startsWith('.') ? '.' : '',
+      co.domain
+    ].join(''),
+    co.hostOnly ? 'FALSE' : 'TRUE',
+    co.path,
+    co.secure ? 'TRUE' : 'FALSE',
+    co.session || !co.expirationDate ? 0 : co.expirationDate,
+    co.name,
+    co.value + '\n'
+  ].join('\t');
+}
+
 /*
 Assign `notify()` as a listener to messages from the content script.
 */
 port.onMessage.addListener(notify);
 
+
 /*
 On a click on the browser action, send the app a message.
 */
 browser.browserAction.onClicked.addListener(function(tab) {
-  console.log('Sending: ' + tab.url);
-  port.postMessage(tab.url);
+  console.log('getting cookies for ' + tab.url);
+  browser.cookies.getAll({url: tab.url}, function(cookie_list) {
+    console.log('found ' + cookie_list.length + ' cookies');
+    console.log('Sending: ' + tab.url);
+    port.postMessage(JSON.stringify({url: tab.url, cookies: cookie_list.map(formatCookie)}));
+  });
 });

--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -3,7 +3,7 @@
   "description": "Run native linux commands from firefox",
   "manifest_version": 2,
   "name": "Command Runner",
-  "version": "1.0",
+  "version": "1.1",
   "icons": {
     "48": "icons/message.svg"
   },
@@ -23,6 +23,11 @@
     "default_icon": "icons/message.svg"
   },
 
-  "permissions": ["nativeMessaging", "notifications", "activeTab"]
-
+  "permissions": [
+    "nativeMessaging",
+    "notifications",
+    "activeTab",
+    "cookies",
+    "<all_urls>"
+  ]
 }

--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
+import os
 import json
 import struct
 import subprocess
-
+import tempfile
 
 # Read a message from stdin and decode it.
 def getMessage():
@@ -12,8 +13,8 @@ def getMessage():
     if len(rawLength) == 0:
         sys.exit(0)
     messageLength = struct.unpack('@I', rawLength)[0]
-    message = sys.stdin.read(messageLength)
-    return json.loads(message)
+    message = sys.stdin.read(messageLength).decode('string_escape').strip("'\"")
+    return message
 
 
 # Encode a message for transmission,
@@ -30,13 +31,41 @@ def sendMessage(encodedMessage):
     sys.stdout.write(encodedMessage['content'])
     sys.stdout.flush()
 
+# thanks @Lennon Hill for the cookie management code (see https://github.com/lennonhill/cookies-txt)
+cookie_header = \
+    '# Netscape HTTP Cookie File\n' + \
+    '# https://curl.haxx.se/rfc/cookie_spec.html\n' + \
+    '# This is a generated file! Do not edit.\n\n';
+
+def makeCookieJar(cookies):
+    subprocess.check_output(['/tmp/echo_me', "making cookie jar"])
+    with tempfile.NamedTemporaryFile(mode='w+t', suffix=".txt", delete=False) as my_jar:
+        my_jar.write(cookie_header)
+        my_jar.write(''.join(cookies))
+        return my_jar.name
 
 while True:
-    receivedMessage = getMessage()
-    # sendMessage(encodeMessage('Starting Download: ' + receivedMessage))
     try:
-        subprocess.check_output(['youtube-dl', receivedMessage])
-        sendMessage(encodeMessage('Finished Downloading: ' + receivedMessage))
-    except subprocess.CalledProcessError:
-        sendMessage(encodeMessage('Some Error Downloading: ' + receivedMessage))
+        receivedMessage = json.loads(getMessage())
+        #receivedMessage = {'url':"--help"}
+    except Exception as err:
+        sendMessage(encodeMessage('JSON error: ' + str(err)))
+
+    # sendMessage(encodeMessage('Starting Download: ' + url))
+    url = receivedMessage.get('url', '');
+    try:
+        command_vec = ['youtube-dl']
+        if os.path.isfile('../config'):
+            command_vec += ['--config-location', '../config']
+        
+        if 'cookies' in receivedMessage and receivedMessage['cookies']:
+            my_jar = makeCookieJar(receivedMessage['cookies'])
+            subprocess.check_output(command_vec + ['--cookies', my_jar, url])
+            os.unlink(my_jar)
+        else:
+            subprocess.check_output(command_vec + [url])
+
+        sendMessage(encodeMessage('Finished Downloading to /data/down: ' + url))
+    except Exception as err:
+        sendMessage(encodeMessage('Some Error Downloading: ' + url + ': ' + str(err)))
 


### PR DESCRIPTION
main changes are:
1) cookie support beta - I did some testing and successfully downloaded videos from login-requiring sites
2) the `config` file is automatically detected in `..` if it exists and is passed to `youtube-dl` via `--config-location`
3) some more exception handling which might come in handy if anyone ever has troubles with this script
4) oh this also updates the shebang to `python2`