### PR TITLE
fixed some problems with the last pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can configure youtube-dl to download only audio, or convert into any desired
 1. Clone this repo
 1. Add the addon [command_runner-1.0-an+fx-linux.xpi](./command_runner-1.0-an+fx-linux.xpi?raw=true) from this repo to firefox by double-clicking.
 1. Edit the file [firefox_command_runner.json](./app/firefox_command_runner.json) and edit the `path` to the location of the file `./app/firefox-command-runner.py` (i.e., where you cloned this repo to.).
+1. Edit the [local youtube-dl config](config) to fit your needs or delete it to use youtube-dl's global configuration
 1. Copy the file `firefox_command_runner.json` to the folder `/home/<username>/.mozilla/native-messaging-hosts/` (replace `<username>` wtih your own username. Create the folder if it does not exist).
 
 ## How to use this addon

--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -47,16 +47,17 @@ def makeCookieJar(cookies):
 while True:
     try:
         my_jar = None
-        receivedMessage = json.loads(getMessage())
-        #receivedMessage = {'url':"--help", 'cookies':['bla']}
+        #receivedMessage = json.loads(getMessage())
+        receivedMessage = {'url':"--help", 'cookies':['bla']}
         url = receivedMessage['url']
         use_cookies = bool('cookies' in receivedMessage and receivedMessage['cookies'])
 
         # sendMessage(encodeMessage('Starting Download: ' + url))
         try:
             command_vec = ['youtube-dl']
-            if os.path.isfile('../config'):
-                command_vec += ['--config-location', '../config']
+            config_path = os.path.join(os.pardir, 'config')
+            if os.path.isfile(config_path):
+                command_vec += ['--config-location', config_path]
             
             if use_cookies:
                 my_jar = makeCookieJar(receivedMessage['cookies'])

--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -46,26 +46,31 @@ def makeCookieJar(cookies):
 
 while True:
     try:
+        my_jar = None
         receivedMessage = json.loads(getMessage())
-        #receivedMessage = {'url':"--help"}
+        #receivedMessage = {'url':"--help", 'cookies':['bla']}
+        url = receivedMessage['url']
+        use_cookies = bool('cookies' in receivedMessage and receivedMessage['cookies'])
+
+        # sendMessage(encodeMessage('Starting Download: ' + url))
+        try:
+            command_vec = ['youtube-dl']
+            if os.path.isfile('../config'):
+                command_vec += ['--config-location', '../config']
+            
+            if use_cookies:
+                my_jar = makeCookieJar(receivedMessage['cookies'])
+                subprocess.check_output(command_vec + ['--cookies', my_jar, url])
+            else:
+                subprocess.check_output(command_vec + [url])
+
+            sendMessage(encodeMessage('Finished Downloading to /data/down: ' + url))
+        except Exception as err:
+            sendMessage(encodeMessage('Some Error Downloading: ' + url + ': ' + str(err)))
+        finally:
+            # be sure to remove the cookie storage even in case of exception
+            if use_cookies and my_jar:
+                os.unlink(my_jar)
     except Exception as err:
         sendMessage(encodeMessage('JSON error: ' + str(err)))
-
-    # sendMessage(encodeMessage('Starting Download: ' + url))
-    url = receivedMessage.get('url', '');
-    try:
-        command_vec = ['youtube-dl']
-        if os.path.isfile('../config'):
-            command_vec += ['--config-location', '../config']
-        
-        if 'cookies' in receivedMessage and receivedMessage['cookies']:
-            my_jar = makeCookieJar(receivedMessage['cookies'])
-            subprocess.check_output(command_vec + ['--cookies', my_jar, url])
-            os.unlink(my_jar)
-        else:
-            subprocess.check_output(command_vec + [url])
-
-        sendMessage(encodeMessage('Finished Downloading to /data/down: ' + url))
-    except Exception as err:
-        sendMessage(encodeMessage('Some Error Downloading: ' + url + ': ' + str(err)))
 


### PR DESCRIPTION
My last pull request created a cookie-leak if youtube-dl would crash midway (cause the cookie jar would not have been unlinked then). Further, I hard-coded "../config" as the path to the config file which would have made windows users unhappy. It should now be portable. Sorry to keep bothering you, mea culpa. 