### PR TITLE
running parallel tasks

### DIFF
--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -6,14 +6,58 @@ import json
 import struct
 import subprocess
 import tempfile
+# a simple POSIX/Unix - only extension ;
+# use something like multiprocessing to make it portable
+import signal as S
+import time
+import select
+import errno as E
+import traceback as tb
+
+# -------------------------------------------------------------------------
+# settings
+
+HOMEDIR = os.environ.get("HOME", '/tmp')
+# replace teh last '.' for 'Downloads' or whatever
+DOWNLOADS = os.path.join( HOMEDIR, '.' )
+WAIT_PERIOD = 1 # select() timeout, seconds
+
+
+# -------------------------------------------------------------------------
+# fixes
+
+# [ https://bugs.python.org/issue1652 ]
+# [ https://docs.python.org/3/library/signal.html#signal.signal ]
+S.signal(S.SIGPIPE, lambda signum, stfr: None)
+
+
+# -------------------------------------------------------------------------
+# logging ( nb: better use syslog for this )
+
+LOGFILE = os.path.join( HOMEDIR, '.mozilla/native-messaging-hosts/firefox-command-runner.log' )
+
+with open(LOGFILE, 'w') as L:
+    print >>L, "SIGPIPE wrapper installed at %s" % ( time.strftime('%F %T'), )
+
+
+def _log(fmt, *args):
+    with open(LOGFILE, 'a') as L:
+        print >>L, fmt % args
+
+
+# -------------------------------------------------------------------------
+# helpers
 
 # Read a message from stdin and decode it.
 def getMessage():
     rawLength = sys.stdin.read(4)
     if len(rawLength) == 0:
-        sys.exit(0)
+        ## sys.exit(0)
+        return None
     messageLength = struct.unpack('@I', rawLength)[0]
-    message = sys.stdin.read(messageLength).decode('string_escape').strip("'\"")
+    raw_message = sys.stdin.read(messageLength)
+    ## _log("| %r", raw_message)
+    message = raw_message.decode('string_escape').strip("'\"")
     return message
 
 
@@ -31,6 +75,9 @@ def sendMessage(encodedMessage):
     sys.stdout.write(encodedMessage['content'])
     sys.stdout.flush()
 
+# -------------------------------------------------------------------------
+# cookie handling code
+
 # thanks @Lennon Hill for the cookie management code (see https://github.com/lennonhill/cookies-txt)
 cookie_header = \
     '# Netscape HTTP Cookie File\n' + \
@@ -43,35 +90,79 @@ def makeCookieJar(cookies):
         my_jar.write(''.join(cookies))
         return my_jar.name
 
+
+# -------------------------------------------------------------------------
+# main loop
+
+tasks = {} # { pid: (my_jar, url) }
+
 while True:
     try:
-        my_jar = None
-        receivedMessage = json.loads(getMessage())
-        #receivedMessage = {'url':"--help", 'cookies':['bla']}
-        url = receivedMessage['url']
-        use_cookies = bool('cookies' in receivedMessage and receivedMessage['cookies'])
+        r_, _, _ = select.select([sys.stdin], [], [], WAIT_PERIOD)
+        if r_:
+        
+            my_jar = None
+            encodedMessage = getMessage()
+            if not encodedMessage:
+                continue
+            # else ..
+            receivedMessage = json.loads(encodedMessage) # if this fails, we try it again
+            #receivedMessage = {'url':"--help", 'cookies':['bla']}
+            url = receivedMessage['url']
+            use_cookies = bool('cookies' in receivedMessage and receivedMessage['cookies'])
 
-        # sendMessage(encodeMessage('Starting Download: ' + url))
-        try:
-            command_vec = ['youtube-dl']
-            config_path = os.path.join(os.pardir, 'config')
-            if os.path.isfile(config_path):
-                command_vec += ['--config-location', config_path]
+            sendMessage(encodeMessage('Starting Download: ' + url))
+            try:
+                command_vec = ['youtube-dl']
+                config_path = os.path.join(os.pardir, 'config')
+                if os.path.isfile(config_path):
+                    command_vec += ['--config-location', config_path]
+
+                if use_cookies:
+                    my_jar = makeCookieJar(receivedMessage['cookies'])
+                    command_vec += ['--cookies', my_jar]
+
+                command_vec.append(url)
+                ## sendMessage(encodeMessage('starting ' + str(command_vec)))
+                ## subprocess.check_output(command_vec)
+                pid = os.fork()
+                if 0 == pid :
+                    subprocess.check_output(command_vec, cwd=DOWNLOADS)
+                    break
+                else:
+                    tasks[ pid ] = ( my_jar, url)
+                    _log("[%s]: %r", pid, url)
             
-            if use_cookies:
-                my_jar = makeCookieJar(receivedMessage['cookies'])
-                command_vec += ['--cookies', my_jar]
+            # todo: review and most likely clear this internal try .. except block
+            except Exception as err:
+                sendMessage(encodeMessage('Error Running: ' + str(command_vec) + ': ' + str(err)))
 
-            command_vec.append(url)
-            #sendMessage(encodeMessage('running ' + str(command_vec)))
-            subprocess.check_output(command_vec)
-            sendMessage(encodeMessage('Finished Downloading to /data/down: ' + url))
-        except Exception as err:
-            sendMessage(encodeMessage('Error Running: ' + str(command_vec) + ': ' + str(err)))
-        finally:
-            # be sure to remove the cookie storage even in case of exception
-            if use_cookies and my_jar:
-                os.unlink(my_jar)
+        if tasks.keys():
+            while True:
+                try:
+                    pid, status = os.waitpid( -1, os.WNOHANG )
+                except OSError as e:
+                    if e.errno == E.ECHILD:
+                        break
+                        
+                if 0 == pid:
+                    break
+                # else
+                my_jar, url = tasks.pop(pid, (None, None))
+                if my_jar is not None:
+                    os.unlink(my_jar)
+                if url is None :
+                    _log('<%s>: unknown task', pid)
+                elif status != 0:
+                    _log('[%s]: %r : FAILED (%08Xh)', pid, url, status)
+                    sendMessage(encodeMessage('Error downloading: %s (%08Xh)' % ( url, status)))
+                else:
+                    _log('[%s]: %r : Ok', pid, url)
+                    sendMessage(encodeMessage('Finished downloading to %s : %r' % ( DOWNLOADS, url)))
+            
+            
     except Exception as err:
+        ## _log('exc: %s', err)
+        _log('exception: %s', tb.format_exc())
         sendMessage(encodeMessage('JSON error: ' + str(err)))
 


### PR DESCRIPTION
Hi, thank you for doing this.

However, the current version seems to have to process the requests sequentially -- that is, wait until the previous download is over.

This is one quick "pure unix" way to parallelize this. To add, it could be done with threads or the processing module to make it more portable. One could also move the `wait` code to a SIGCHILD handler to make the code look more clean. However, Python signal handlers are not exactly C signal handlers, so it could be easier to just leave it where it is.

Finally, some syslog-based logging might be more appropriate, OTOH file-based one may make it easier to communicate with the users.

Happy New Year to all of us )