### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ You can configure youtube-dl to download only audio, or convert into any desired
 
 1. Clone this repo
 2. Install the add on from [Firefox Addons Website](https://addons.mozilla.org/en-US/firefox/addon/youtube-dl-for-linux/). Or you can install the addon [command_runner-1.0-an+fx-linux.xpi](./command_runner-1.0-an+fx-linux.xpi?raw=true) from this repo to firefox by double-clicking.
-3. Edit the file [firefox_command_runner.json](./app/firefox_command_runner.json) and edit the `path` to the location of the file `./app/firefox-command-runner.py` (i.e., where you cloned this repo to.).
-4. Edit the [local youtube-dl config](config) to fit your needs or delete it to use youtube-dl's global configuration
-5. Copy the file `firefox_command_runner.json` to the folder `/home/<username>/.mozilla/native-messaging-hosts/` (replace `<username>` wtih your own username. Create the folder if it does not exist).
+3. Edit the [local youtube-dl config](config) to fit your needs or delete it to use youtube-dl's global configuration
+4. Run `./preinstall.py` (from the root of the downloaded code repository) to create required accessory files, or _instead_ do the two following steps by hand:
+
+4-alt-1. Edit the file [firefox_command_runner.json](./app/firefox_command_runner.json) and edit the `path` to the location of the file `./app/firefox-command-runner.py` (i.e., where you cloned this repo to.).
+
+4-alt-2. Copy the file `firefox_command_runner.json` to the folder `/home/<username>/.mozilla/native-messaging-hosts/` (replace `<username>` wtih your own username. Create the folder if it does not exist).
 
 ## How to use this addon
 

--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -40,7 +40,21 @@ S.signal(S.SIGPIPE, lambda signum, stfr: None)
 # -------------------------------------------------------------------------
 # logging ( nb: better use syslog for this )
 
-LOGFILE = os.path.join( HOMEDIR, '.mozilla/native-messaging-hosts/firefox-command-runner.log' )
+# try to get preferred log directory from the json file, 
+# use the same path otherwise
+LOGDIR = None
+try:
+    jsonfile = sys.argv[1]
+    jsondata = json.loads(open(jsonfile).read())
+    LOGDIR = jsondata.get('logdir', None)
+except:
+    pass
+
+if LOGDIR is None:
+    LOGDIR = os.path.join( HOMEDIR, '.mozilla/native-messaging-hosts' )
+
+LOGFILE = os.path.join( LOGDIR, 'firefox-command-runner.log' )
+
 
 with open(LOGFILE, 'w') as L:
     print >>L, "SIGPIPE wrapper installed at %s" % ( time.strftime('%F %T'), )

--- a/app/firefox-command-runner.py
+++ b/app/firefox-command-runner.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python2
 
+""" This is started (by firefox) as follows: 
+
+    python2 $HOME/.mozilla/native-messaging-hosts/firefox-command-runner.py    \
+            $HOME/.mozilla/native-messaging-hosts/firefox_command_runner.json  \
+            firefox-command-runner@example.org
+"""
+
 import sys
 import os
 import json
@@ -18,10 +25,9 @@ import traceback as tb
 # settings
 
 HOMEDIR = os.environ.get("HOME", '/tmp')
-# replace teh last '.' for 'Downloads' or whatever
+# replace the last '.' for 'Downloads' or whatever
 DOWNLOADS = os.path.join( HOMEDIR, '.' )
 WAIT_PERIOD = 1 # select() timeout, seconds
-
 
 # -------------------------------------------------------------------------
 # fixes
@@ -44,6 +50,12 @@ def _log(fmt, *args):
     with open(LOGFILE, 'a') as L:
         print >>L, fmt % args
 
+# firefox' process id
+PPID = None
+try:
+    PPID = os.getppid()
+except Exception as err:
+    _log('exception: %s', tb.format_exc())
 
 # -------------------------------------------------------------------------
 # helpers
@@ -95,9 +107,17 @@ def makeCookieJar(cookies):
 # main loop
 
 tasks = {} # { pid: (my_jar, url) }
+# "reverse index"
+urls = {}
 
 while True:
     try:
+        # check parent: somehow firefox does not always close us
+        ppid = os.getppid()
+        if PPID != ppid:
+            _log("/ppid/ %d != %d /original ppid/, so it's probably time to go", ppid, PPID)
+            os.exit(2)
+
         r_, _, _ = select.select([sys.stdin], [], [], WAIT_PERIOD)
         if r_:
         
@@ -111,44 +131,61 @@ while True:
             url = receivedMessage['url']
             use_cookies = bool('cookies' in receivedMessage and receivedMessage['cookies'])
 
-            sendMessage(encodeMessage('Starting Download: ' + url))
-            try:
-                command_vec = ['youtube-dl']
-                config_path = os.path.join(os.pardir, 'config')
-                if os.path.isfile(config_path):
-                    command_vec += ['--config-location', config_path]
+            if url not in urls:
+                sendMessage(encodeMessage('Starting download: ' + url))
+                try:
+                    command_vec = ['youtube-dl']
+                    config_path = os.path.join(os.pardir, 'config')
+                    if os.path.isfile(config_path):
+                        command_vec += ['--config-location', config_path]
 
-                if use_cookies:
-                    my_jar = makeCookieJar(receivedMessage['cookies'])
-                    command_vec += ['--cookies', my_jar]
+                    if use_cookies:
+                        my_jar = makeCookieJar(receivedMessage['cookies'])
+                        command_vec += ['--cookies', my_jar]
 
-                command_vec.append(url)
-                ## sendMessage(encodeMessage('starting ' + str(command_vec)))
-                ## subprocess.check_output(command_vec)
-                pid = os.fork()
-                if 0 == pid :
-                    subprocess.check_output(command_vec, cwd=DOWNLOADS)
-                    break
-                else:
-                    tasks[ pid ] = ( my_jar, url)
-                    _log("[%s]: %r", pid, url)
-            
-            # todo: review and most likely clear this internal try .. except block
-            except Exception as err:
-                sendMessage(encodeMessage('Error Running: ' + str(command_vec) + ': ' + str(err)))
+                    command_vec.append(url)
+                    ## sendMessage(encodeMessage('starting ' + str(command_vec)))
+                    ## subprocess.check_output(command_vec)
+                    pid = os.fork()
+                    if 0 == pid :
+                        try:
+                            subprocess.check_output(command_vec, cwd=DOWNLOADS)
+                        except:
+                            pass
+                        finally:
+                            # exit the child process
+                            sys.exit(0)
+                    else:
+                        tasks[ pid ] = ( my_jar, url)
+                        urls[ url ] = pid
+                        _log("[%s]: %r", pid, url)
+                
+                # todo: review and most likely clear this internal try .. except block
+                except Exception as err:
+                    sendMessage(encodeMessage('Error Running: ' + str(command_vec) + ': ' + str(err)))
+            else:
+                sendMessage(encodeMessage('Already downloading: ' + url))
 
         if tasks.keys():
             while True:
                 try:
                     pid, status = os.waitpid( -1, os.WNOHANG )
                 except OSError as e:
+                    # no more children to wait for so far
                     if e.errno == E.ECHILD:
                         break
-                        
-                if 0 == pid:
+
+                # children exist, but did not yet change state
+                if 0 == pid: 
                     break
+
                 # else
                 my_jar, url = tasks.pop(pid, (None, None))
+                
+                if url is not None:
+                    if url in urls:
+                        del urls[url]
+                
                 if my_jar is not None:
                     os.unlink(my_jar)
                 if url is None :

--- a/preinstall.py
+++ b/preinstall.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python2
+
+""" 
+    Installation helper for our addon.
+    
+    By default, this puts both firefox-command-runner.py and firefox-command-runner.json 
+    under "$HOME/.mozilla/native-messaging-hosts", and edits the latter accordingly.
+    
+    This behaviour can be altered with a few options -- please see `./preinstall.py --help`
+"""
+
+import os
+import sys
+import optparse
+import json
+import shutil
+import errno
+
+# 1. create "$HOME/.mozilla/native-messaging-hosts"
+# 2. locate 'firefox-command-runner.py' and put it there or as specified
+# 3. update the dictionary and save it there as "firefox-command-runner.json"
+
+
+# -------------------------------------------------------------------------
+# installer data: app/firefox-command-runner.json
+
+# // or use json.loads( open('app/firefox-command-runner.json').read() )
+JSON_DATA = {
+  "name": "firefox_command_runner",
+  "description": "Run native linux commands from firefox",
+  "path": "/home/akhil/opt/firefox-command-runner/app/firefox-command-runner.py",
+  "type": "stdio",
+  "allowed_extensions": [ "firefox-command-runner@example.org" ]
+}
+
+
+# -------------------------------------------------------------------------
+# options and help strings
+
+
+USAGE = """
+
+By default, this will install app/firefox-command-runner.py' 
+under "$HOME/.mozilla/native-messaging-hosts", 
+along with a 'firefox-command-runner.json' file.
+
+This machinery is needed by our FF extension to work.
+
+See below for available options.
+
+""".strip() 
+
+
+# [ https://wiki.python.org/moin/OptParse ]
+parser = optparse.OptionParser( USAGE )
+
+parser.add_option( '--appdir', '-A'
+                 , action="store", dest="command_runner_dir", metavar='APPDIR'
+                 , default=None
+                 , help = "where to put firefox-command-runner.py" ) 
+
+parser.add_option( '--logdir', '-L'
+                 , action="store", dest="logdir"
+                 , default=None
+                 , help = "where to put the log file (rewritten at every restart)" ) 
+
+
+# parse command line for options 
+options, args = parser.parse_args( sys.argv )
+
+
+
+# -------------------------------------------------------------------------
+# accessory code
+
+# 'HOME' is guaranteed by POSIX -- see e.g. this Open Group spec:
+# [ https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html ]
+# .. hence, we do not expect it to be missing and consider that a severe error
+HOME = os.environ.get('HOME', None)
+
+# By default, Firefox would expect "native messaging" folder 
+# // https://wiki.mozilla.org/WebExtensions/Native_Messaging
+# to be here
+FF_NMDIR = os.path.join( HOME, '.mozilla/native-messaging-hosts' )
+
+
+def mkdir(path):
+    """ in shell terms, it's "mkdir -p $path" """
+    
+    try:
+        os.makedirs( path )
+    except OSError as e:
+        if errno.EEXIST != e.errno:
+            raise
+
+
+# -------------------------------------------------------------------------
+# ok, let us do our prerequisite install
+
+# 1. create "$HOME/.mozilla/native-messaging-hosts"
+mkdir( FF_NMDIR )
+
+# 2. locate 'firefox-command-runner.py' and put it there or as specified
+FF_RUNNER_PATH = options.command_runner_dir
+if FF_RUNNER_PATH is None:
+    FF_RUNNER_PATH = FF_NMDIR
+
+shutil.copy( 'app/firefox-command-runner.py', FF_RUNNER_PATH )
+
+# 3. update the dictionary and save it there as "firefox-command-runner.json"
+runner_fullname = os.path.join( FF_RUNNER_PATH, 'firefox-command-runner.py' )
+JSON_DATA['path'] = runner_fullname
+
+if options.logdir is not None:
+    JSON_DATA['logdir'] = options.logdir
+
+with open( os.path.join(FF_NMDIR, 'firefox-command-runner.json'), 'w' ) as jsonfile:
+    
+    json.dump(JSON_DATA, jsonfile, indent=2)
+


### PR DESCRIPTION
[f94abcf](https://github.com/thread13/youtube-dl-firefox-addon/commit/f94abcfb4eb0c6cf4c46d3195184c111f45e4e4f) is the most important one:
 * makes the script quit if the parent process dies without shutting it down
 * adds a simple change to ignore multiple requests for the same url
 
The other three commits basically introduce [./preinstall.py](https://github.com/thread13/youtube-dl-firefox-addon/blob/dev/preinstall.py) as a method to automate manual directory creation for Firefox' native messaging, and editing the related `.json` file -- along with a proposed change to the README file.

The latter is tested only very briefly, so I could have missed some necessary corrections; however, I believe that running `./preinstall.py` is a somewhat easier way to install `firefox-command-runner.py` etc.

As before -- many thanks for your work!